### PR TITLE
Fix tree shaking and small changes

### DIFF
--- a/generators/scaffold/resources/package.json
+++ b/generators/scaffold/resources/package.json
@@ -31,19 +31,20 @@
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/preset-env": "^7.9.5",
     "@babel/preset-react": "^7.9.4",
+    "@rollup/plugin-commonjs": "^11.1.0",
+    "@rollup/plugin-node-resolve": "^7.1.2",
+    "@rollup/plugin-url": "^4.0.2",
     "@svgr/rollup": "^5.3.1",
     "babel-eslint": "^10.1.0",
     "cross-env": "^7.0.2",
-    "eslint": "^6.8.0",
     "eslint-plugin-react": "^7.19.0",
-    "react": "^16.13.1",
+    "eslint": "^6.8.0",
     "react-dom": "^16.13.1",
-    "rollup": "^2.6.0",
+    "react": "^16.13.1",
+    "rollup-plugin-auto-external": "^2.0.0",
     "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-peer-deps-external": "^2.2.2",
     "rollup-plugin-postcss": "^2.5.0",
-    "rollup-plugin-url": "^3.0.1"
+    "rollup-plugin-terser": "^5.3.0",
+    "rollup": "^2.6.0"
   }
 }

--- a/generators/scaffold/resources/package.json
+++ b/generators/scaffold/resources/package.json
@@ -1,7 +1,7 @@
 {
   "version": "0.0.0",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "jsnext:main": "dist/index.es.js",
   "files": [

--- a/generators/scaffold/resources/package.json
+++ b/generators/scaffold/resources/package.json
@@ -4,6 +4,9 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "jsnext:main": "dist/index.es.js",
+  "sideEffects": [
+    "*.css"
+  ],
   "files": [
     "dist"
   ],

--- a/generators/scaffold/resources/package.json
+++ b/generators/scaffold/resources/package.json
@@ -25,6 +25,9 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },
+  "dependencies": {
+    "classnames": "^2.2.6"
+  },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",

--- a/generators/scaffold/templates/rollup.config.js
+++ b/generators/scaffold/templates/rollup.config.js
@@ -1,10 +1,11 @@
 import babel from 'rollup-plugin-babel';
-import commonjs from 'rollup-plugin-commonjs';
-import external from 'rollup-plugin-peer-deps-external';
+import commonjs from '@rollup/plugin-commonjs';
+import external from 'rollup-plugin-auto-external';
 import postcss from 'rollup-plugin-postcss';
-import resolve from 'rollup-plugin-node-resolve';
-import url from 'rollup-plugin-url';
+import resolve from '@rollup/plugin-node-resolve';
 import svgr from '@svgr/rollup';
+import url from '@rollup/plugin-url';
+import { terser } from 'rollup-plugin-terser';
 
 import pkg from './package.json';
 
@@ -23,16 +24,20 @@ export default {
     },
   ],
   plugins: [
-    external(),
+    babel({
+      exclude: 'node_modules/**',
+      runtimeHelpers: true,
+    }),
+    external({
+      includeDependencies: true,
+    }),
+    resolve(),
+    commonjs(),
     postcss({
       modules: true,
     }),
     url(),
     svgr(),
-    babel({
-      exclude: 'node_modules/**',
-    }),
-    resolve(),
-    commonjs(),
+    terser(),
   ],
 };

--- a/generators/scaffold/templates/src/Button/Button.css
+++ b/generators/scaffold/templates/src/Button/Button.css
@@ -1,5 +1,5 @@
 /* add css styles here (optional) */
 
-button {
+.Button {
   background-color: tomato;
 }

--- a/generators/scaffold/templates/src/Button/Button.js
+++ b/generators/scaffold/templates/src/Button/Button.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
-import './Button.css';
+import css from './Button.css';
 
-const Button = props => {
-  return <button {...props} />;
+const Button = ({ className, ...rest }) => {
+  return <button className={classnames(css.Button, className)} {...rest} />;
 };
 
 Button.propTypes = {


### PR DESCRIPTION
- prefix common js output;
- update all rollup plugins;
- add classnames as dependencies;
- use `rollup-plugin-auto-external`;
- use css modules in the example to proper build
- add terser to minify output